### PR TITLE
fix(parser): 単独の S/C/A/W セルを修飾キープレフィックスと誤認しないよう修正

### DIFF
--- a/crates/kikyo-core/src/parser.rs
+++ b/crates/kikyo-core/src/parser.rs
@@ -360,29 +360,25 @@ fn parse_key_sequence_expanded_with_mode(
     while i < chars.len() {
         let c = chars[i];
 
-        // Check for modifiers
-        match c {
-            'S' => {
-                current_mods.shift = true;
+        // Check for modifiers -- but only consume as a modifier prefix if there's
+        // a non-modifier character following. Otherwise, treat as a literal letter.
+        // This preserves "Sa" -> Shift+a while making bare "S" output literal "S"
+        // (needed by layouts that assign a bare uppercase S/C/A/W to a cell).
+        if matches!(c, 'S' | 'C' | 'A' | 'W') {
+            let has_following_non_modifier =
+                (i + 1..chars.len()).any(|j| !matches!(chars[j], 'S' | 'C' | 'A' | 'W'));
+            if has_following_non_modifier {
+                match c {
+                    'S' => current_mods.shift = true,
+                    'C' => current_mods.ctrl = true,
+                    'A' => current_mods.alt = true,
+                    'W' => current_mods.win = true,
+                    _ => unreachable!(),
+                }
                 i += 1;
                 continue;
             }
-            'C' => {
-                current_mods.ctrl = true;
-                i += 1;
-                continue;
-            }
-            'A' => {
-                current_mods.alt = true;
-                i += 1;
-                continue;
-            }
-            'W' => {
-                current_mods.win = true;
-                i += 1;
-                continue;
-            }
-            _ => {}
+            // Else fall through to default parsing (treat as literal letter).
         }
 
         let (mut strokes, consumed) = parse_unit(&chars[i..], mode, kb_map);
@@ -1060,10 +1056,10 @@ mod tests {
         );
 
         // Case sensitivity check
-        // "A" is now treated as Alt modifier, so it produces no keystroke locally if not followed by a key.
+        // "A" alone is NOT a modifier prefix (no following key), so it produces literal 'A'.
         assert_eq!(
             parse_token("A", &crate::keyboard_map::new_jis_106()),
-            Token::None
+            Token::KeySequence(vec![stroke_char('A')])
         );
         assert_eq!(
             parse_token("Ａ", &crate::keyboard_map::new_jis_106()), // Fullwidth A
@@ -1124,11 +1120,11 @@ mod tests {
 
         // Modifiers (single-stroke)
 
-        // Modifiers (single-stroke)
-        // "CA" -> Ctrl + Alt (accumulated modifiers, no key)
+        // "CA" without a following key -> literal 'C' and 'A' (NOT modifier prefixes,
+        // since there's no non-modifier character after).
         assert_eq!(
             parse_token("CA", &crate::keyboard_map::new_jis_106()),
-            Token::None
+            Token::KeySequence(vec![stroke_char('C'), stroke_char('A')])
         );
 
         // "Cａ" -> Ctrl + a
@@ -1139,6 +1135,22 @@ mod tests {
                 mods: Modifiers {
                     ctrl: true,
                     shift: false,
+                    alt: false,
+                    win: false,
+                },
+            }])
+        );
+
+        // "Sa" (ASCII trailing key) -> Shift + a: the modifier prefix IS
+        // consumed because a non-modifier character follows. Regression guard
+        // for the preservation case the commit message names explicitly.
+        assert_eq!(
+            parse_token("Sa", &crate::keyboard_map::new_jis_106()),
+            Token::KeySequence(vec![KeyStroke {
+                key: KeySpec::Char('a'),
+                mods: Modifiers {
+                    ctrl: false,
+                    shift: true,
                     alt: false,
                     win: false,
                 },
@@ -1228,10 +1240,65 @@ mod tests {
             }])
         );
 
-        // "S" -> Empty (No key following)
+        // "S" alone -> literal 'S' character (no key follows the S, so it's NOT
+        // a modifier prefix). This matters for layouts that assign a bare
+        // uppercase letter S/C/A/W to a cell, which should output that letter.
         assert_eq!(
             parse_token("S", &crate::keyboard_map::new_jis_106()),
-            Token::None
+            Token::KeySequence(vec![KeyStroke {
+                key: KeySpec::Char('S'),
+                mods: Modifiers::none(),
+            }])
+        );
+
+        // "C" alone -> literal 'C'
+        assert_eq!(
+            parse_token("C", &crate::keyboard_map::new_jis_106()),
+            Token::KeySequence(vec![KeyStroke {
+                key: KeySpec::Char('C'),
+                mods: Modifiers::none(),
+            }])
+        );
+
+        // "A" alone -> literal 'A'
+        assert_eq!(
+            parse_token("A", &crate::keyboard_map::new_jis_106()),
+            Token::KeySequence(vec![KeyStroke {
+                key: KeySpec::Char('A'),
+                mods: Modifiers::none(),
+            }])
+        );
+
+        // "W" alone -> literal 'W'
+        assert_eq!(
+            parse_token("W", &crate::keyboard_map::new_jis_106()),
+            Token::KeySequence(vec![KeyStroke {
+                key: KeySpec::Char('W'),
+                mods: Modifiers::none(),
+            }])
+        );
+
+        // "SCAW" (all modifiers, no following key) -> literal characters S, C, A, W
+        assert_eq!(
+            parse_token("SCAW", &crate::keyboard_map::new_jis_106()),
+            Token::KeySequence(vec![
+                KeyStroke {
+                    key: KeySpec::Char('S'),
+                    mods: Modifiers::none(),
+                },
+                KeyStroke {
+                    key: KeySpec::Char('C'),
+                    mods: Modifiers::none(),
+                },
+                KeyStroke {
+                    key: KeySpec::Char('A'),
+                    mods: Modifiers::none(),
+                },
+                KeyStroke {
+                    key: KeySpec::Char('W'),
+                    mods: Modifiers::none(),
+                },
+            ])
         );
     }
 


### PR DESCRIPTION
## 概要

レイアウト定義で 1 セルに大文字の `S` `C` `A` `W` を単独で割り当てると、
`parse_key_sequence_expanded_with_mode` が後続キーの有無を確認せずに修飾キー
プレフィックスとして消費してしまい、当該セルが文字を出力せず物理キーの
素通し結果になる不具合を修正します。

修正方針: 修飾キープレフィックスとして消費するのは「後続に non-modifier な
文字がある時だけ」に限定。`Sa` `SCa` 等の複合修飾子表記は従来どおり動作します。
詳細はコミットメッセージに記載しています。

## 変更内容

- `crates/kikyo-core/src/parser.rs`: 修飾子プレフィックス判定の修正、および
  既存テストの新仕様への更新＋単独 `S/C/A/W`・`SCAW` のリテラル化と
  `Sa`->Shift+a 保全の assert 追加

## テスト

`upstream/main` 基点の単独 worktree で `cargo test -p kikyo-core --lib` を複数回実行して検証しました。

- 本 PR が更新・追加したテスト assert は、複数回の実行ですべて決定的に通過します。
- `upstream/main` 自体に本 PR と無関係の既存失敗テストがあります。次の 4 件は `upstream/main` 単独で決定的に失敗します: `test_romaji_pinky_shift_fullwidth_uppercase_emits_uppercase_keystroke`, `test_romaji_pinky_shift_kana_sends_romaji_scancodes`, `test_shift_rollover_chord_fallback_preserves_shift`, `test_shifted_layout`（加えて統合テスト `test_ctrl`）。さらに shift / rollover 系の時間依存テスト（`test_pinky_shift_rollover_bypass_keeps_shifted_state` 等）が実行環境の負荷により断続的に失敗し、失敗するテストの顔ぶれと件数が run ごとに揺れます（この負荷依存の集合は網羅的には列挙できません）。
- これらはいずれも本 PR と無関係です。`upstream/main` と本 PR を同条件で複数回実行して比較した結果、失敗するテスト名の集合は一致し、本 PR が新たに失敗させるテストはありません（本 PR 起因の新規失敗ゼロ）。

## 既知の挙動差分

本修正は「後続に non-modifier 文字を伴わない単独の S/C/A/W は
リテラル文字として扱う」という規則に統一します。この規則を一貫して
適用する結果、`SaS` のように修飾子文字・後続文字・さらに末尾の
修飾子文字が連なる ill-formed なセル定義で、出力が変わります。

- 旧挙動: 末尾の `S` が Shift 修飾子として消費されますが、適用先と
  なる後続キーが無いまま定義末尾に達するため、その修飾子は出力に
  反映されず暗黙に破棄されます（結果: `Shift+a` のみ）。
- 新挙動: 「後続が無い単独 S/C/A/W はリテラル」の規則により、末尾
  の `S` はリテラル文字として出力されます（結果: `Shift+a` と `S`）。

この差分は実用的なレイアウトでは発生しません。修飾子文字と通常
文字を上記の順で混在させた病的なセル定義でのみ生じ、かつ旧挙動
（末尾修飾子の暗黙の破棄）も意図された動作ではありません。新挙動
は本修正の方針（後続を伴わない S/C/A/W はリテラル）と一貫した
副作用であり、暗黙の破棄よりも挙動が予測可能になります。

## 関連 PR

これは `forestail/Kikyo` の複数の独立した不具合を、論理バグ単位で個別の PR に分割した一連の修正の一つです。各 PR は `upstream/main` から独立に分岐し、単独でビルド・テストが通ります。

- parser の修飾子プレフィックス誤認修正（`parser.rs`）
- 未定義 3 キー chord の 2 キー分解（`engine.rs`）
- ロール入力時の chord 検出・pending 修正（`chord_engine.rs` ＋ `engine.rs` の `PendingKey` 初期化）
- US 101/104 配列の scancode 修正（`engine.rs` ＋ `keyboard_map.rs`）
- 空 DirectString の no-op 化 ＋ shift 再注入修正（`engine.rs` の `append_keystroke_events`）

これらはファイル・変更領域が分離しており、任意の順序でマージできます。

- US 101/104 scancode 修正 は `append_keystroke_events` のレイアウト対応版（`append_keystroke_events_layout`）を追加し、従来の `append_keystroke_events`（シグネチャ不変）はそれへ委譲する後方互換ラッパーとして残します。他 PR を含む既存の呼び出し側は変更不要です。
- chord 検出修正 は `PendingKey` にフィールドを追加し、その初期化箇所も同 PR 内で更新します（自己完結）。他 PR は `PendingKey` を新規構築しないため影響を受けません。

Closes #10
