### PR TITLE
fix(engine): 文字->scancode 変換を keyboard layout 対応にし US 101/104 の記号を正しく出力

### DIFF
--- a/crates/kikyo-core/src/engine.rs
+++ b/crates/kikyo-core/src/engine.rs
@@ -3,7 +3,7 @@ use crate::chord_engine::{
     ChordEngine, Decision, ImeMode, KeyEdge, KeyEvent, PendingKey, Profile, ThumbShiftSinglePress,
     EXTENDED_KEY_1_SC, EXTENDED_KEY_2_SC, EXTENDED_KEY_3_SC, EXTENDED_KEY_4_SC,
 };
-use crate::keyboard_map::KeyboardMap;
+use crate::keyboard_map::{KeyboardLayout, KeyboardMap};
 use crate::types::{InputEvent, KeyAction, KeySpec, KeyStroke, Layout, Modifiers, ScKey, Token};
 use parking_lot::Mutex;
 use std::cell::RefCell;
@@ -1836,13 +1836,14 @@ impl Engine {
                         committed_for_uppercase = true;
                     }
                     // Strict scancode only for KeySequence (which now comes from single-quote/bare tokens)
-                    append_keystroke_events(
+                    append_keystroke_events_layout(
                         &mut events,
                         stroke,
                         effective_shift_held,
                         false,
                         is_japanese,
                         is_kana_input,
+                        self.keyboard_map.layout(),
                     );
                 }
                 if events.is_empty() {
@@ -2340,6 +2341,19 @@ fn function_key_scancode_from_name(name: &str) -> Option<u16> {
     }
 }
 
+// Backward-compatible wrapper: keeps the original 6-argument arity callable
+// by delegating to the layout-aware `append_keystroke_events_layout` with
+// `KeyboardLayout::Jis`, which is exactly the behavior before layout support
+// was added.
+//
+// This arity has no caller within this change: the production call site was
+// moved to the layout-aware variant. The wrapper is retained so that a
+// separate, independent fix -- which adds a regression test exercising the
+// original 6-argument arity in this file's test module -- keeps compiling
+// when both changes land together, without forcing that unrelated change to
+// adapt to this signature change. `dead_code` is allowed because, within
+// this change alone, the original arity has no caller.
+#[allow(dead_code)]
 fn append_keystroke_events(
     events: &mut Vec<InputEvent>,
     stroke: &KeyStroke,
@@ -2348,10 +2362,30 @@ fn append_keystroke_events(
     is_japanese: bool,
     _is_kana_input: bool,
 ) {
+    append_keystroke_events_layout(
+        events,
+        stroke,
+        shift_held,
+        allow_unicode_fallback,
+        is_japanese,
+        _is_kana_input,
+        KeyboardLayout::Jis,
+    )
+}
+
+fn append_keystroke_events_layout(
+    events: &mut Vec<InputEvent>,
+    stroke: &KeyStroke,
+    shift_held: bool,
+    allow_unicode_fallback: bool,
+    is_japanese: bool,
+    _is_kana_input: bool,
+    kb_layout: KeyboardLayout,
+) {
     let key_events = match stroke.key {
         KeySpec::Scancode(sc, ext) => Some((sc, ext, false)),
         KeySpec::VirtualKey(vk) => vk_to_scancode(vk).map(|(s, e)| (s, e, false)),
-        KeySpec::Char(c) => char_to_scancode(c, is_japanese),
+        KeySpec::Char(c) => char_to_scancode(c, is_japanese, kb_layout),
         KeySpec::ImeOn => {
             events.push(InputEvent::ImeControl(true));
             return;
@@ -2419,16 +2453,89 @@ fn vk_to_scancode(vk: u16) -> Option<(u16, bool)> {
     crate::keyboard_hook::vk_to_scancode(vk)
 }
 
-fn char_to_scancode(c: char, is_japanese: bool) -> Option<(u16, bool, bool)> {
-    // JP-Specific overrides
+/// US 101/104 char -> (scancode, ext, needs_shift) for symbols and shifted
+/// punctuation. Alphanumerics, space, arrows, BS/Enter etc. are intentionally
+/// not handled here so the caller can fall back to the JIS table where they
+/// are identical. Returns None for chars that should fall through.
+fn char_to_scancode_us(c: char) -> Option<(u16, bool, bool)> {
+    match c {
+        // Base row 0 (number row)
+        '`' => Some((0x29, false, false)),
+        '~' => Some((0x29, false, true)),
+        '!' => Some((0x02, false, true)),
+        '@' => Some((0x03, false, true)),
+        '#' => Some((0x04, false, true)),
+        '$' => Some((0x05, false, true)),
+        '%' => Some((0x06, false, true)),
+        '^' => Some((0x07, false, true)),
+        '&' => Some((0x08, false, true)),
+        '*' => Some((0x09, false, true)),
+        '(' => Some((0x0A, false, true)),
+        ')' => Some((0x0B, false, true)),
+        '-' => Some((0x0C, false, false)),
+        '_' => Some((0x0C, false, true)),
+        '=' => Some((0x0D, false, false)),
+        '+' => Some((0x0D, false, true)),
+
+        // Row 1 right side
+        '[' => Some((0x1A, false, false)),
+        '{' => Some((0x1A, false, true)),
+        ']' => Some((0x1B, false, false)),
+        '}' => Some((0x1B, false, true)),
+        '\\' => Some((0x2B, false, false)),
+        '|' => Some((0x2B, false, true)),
+
+        // Row 2 right side
+        ';' => Some((0x27, false, false)),
+        ':' => Some((0x27, false, true)),
+        '\'' => Some((0x28, false, false)),
+        '"' => Some((0x28, false, true)),
+
+        // Row 3 right side (these match JIS but listed for clarity)
+        ',' => Some((0x33, false, false)),
+        '<' => Some((0x33, false, true)),
+        '.' => Some((0x34, false, false)),
+        '>' => Some((0x34, false, true)),
+        '/' => Some((0x35, false, false)),
+        '?' => Some((0x35, false, true)),
+
+        _ => None,
+    }
+}
+
+fn char_to_scancode(
+    c: char,
+    is_japanese: bool,
+    kb_layout: KeyboardLayout,
+) -> Option<(u16, bool, bool)> {
+    // JP-Specific overrides -- sent as keystrokes that the IME interprets.
+    // The "[" / "]" physical key is what the IME maps to "「" / "」", but
+    // that key has a different scancode on JIS vs US, so we have to pick
+    // the right scancode for the physical layout.
     if is_japanese {
         match c {
-            '、' => return Some((0x33, false, false)), // ,
-            '。' => return Some((0x34, false, false)), // .
-            '・' => return Some((0x35, false, false)), // /
-            '「' => return Some((0x1B, false, false)), // [
-            '」' => return Some((0x2B, false, false)), // ]
+            '、' => return Some((0x33, false, false)),
+            '。' => return Some((0x34, false, false)),
+            '・' => return Some((0x35, false, false)),
+            '「' => {
+                return Some(match kb_layout {
+                    KeyboardLayout::Jis => (0x1B, false, false), // JIS [
+                    _ => (0x1A, false, false),                   // US [
+                });
+            }
+            '」' => {
+                return Some(match kb_layout {
+                    KeyboardLayout::Jis => (0x2B, false, false), // JIS ]
+                    _ => (0x1B, false, false),                   // US ]
+                });
+            }
             _ => {}
+        }
+    }
+
+    if matches!(kb_layout, KeyboardLayout::Us | KeyboardLayout::Ax) {
+        if let Some(v) = char_to_scancode_us(c) {
+            return Some(v);
         }
     }
 
@@ -2560,16 +2667,82 @@ mod tests {
 
     #[test]
     fn test_char_to_scancode() {
-        // Updated to use 2 args (is_japanese=false) and return 3-tuple (sc, ext, shift)
-        assert_eq!(char_to_scancode('－', false), Some((0x0C, false, false)));
-        assert_eq!(char_to_scancode('ー', false), Some((0x0C, false, false)));
-        assert_eq!(char_to_scancode('1', false), Some((0x02, false, false)));
-        assert_eq!(char_to_scancode('a', false), Some((0x1E, false, false)));
-        // Shifted char
-        assert_eq!(char_to_scancode('!', false), Some((0x02, false, true)));
-        // Japanese punctuation
-        assert_eq!(char_to_scancode('。', true), Some((0x34, false, false)));
-        assert_eq!(char_to_scancode('。', false), None); // Should fallback to unicode if not JP mode scancode mapping
+        // JIS layout (default). 3-tuple: (sc, ext, needs_shift)
+        let jis = KeyboardLayout::Jis;
+        assert_eq!(
+            char_to_scancode('－', false, jis),
+            Some((0x0C, false, false))
+        );
+        assert_eq!(
+            char_to_scancode('ー', false, jis),
+            Some((0x0C, false, false))
+        );
+        assert_eq!(
+            char_to_scancode('1', false, jis),
+            Some((0x02, false, false))
+        );
+        assert_eq!(
+            char_to_scancode('a', false, jis),
+            Some((0x1E, false, false))
+        );
+        // Shifted char (JIS)
+        assert_eq!(char_to_scancode('!', false, jis), Some((0x02, false, true)));
+        // Japanese punctuation (IME-on path)
+        assert_eq!(
+            char_to_scancode('。', true, jis),
+            Some((0x34, false, false))
+        );
+        assert_eq!(char_to_scancode('。', false, jis), None);
+    }
+
+    #[test]
+    fn test_char_to_scancode_us() {
+        // US 101/104 layout. Symbols differ from JIS.
+        let us = KeyboardLayout::Us;
+        // alphanumerics share the JIS encoding
+        assert_eq!(char_to_scancode('a', false, us), Some((0x1E, false, false)));
+        assert_eq!(char_to_scancode('1', false, us), Some((0x02, false, false)));
+        // ' is unshifted on US (JIS would emit Shift+7)
+        assert_eq!(
+            char_to_scancode('\'', false, us),
+            Some((0x28, false, false))
+        );
+        // " is Shift+0x28 on US (JIS would emit Shift+2)
+        assert_eq!(char_to_scancode('"', false, us), Some((0x28, false, true)));
+        // @ is Shift+2 on US (JIS would emit unshifted 0x1A)
+        assert_eq!(char_to_scancode('@', false, us), Some((0x03, false, true)));
+        // & is Shift+7 on US (JIS would emit Shift+6)
+        assert_eq!(char_to_scancode('&', false, us), Some((0x08, false, true)));
+        // ( is Shift+9 on US (JIS would emit Shift+8)
+        assert_eq!(char_to_scancode('(', false, us), Some((0x0A, false, true)));
+        // [ is unshifted 0x1A on US (JIS would emit unshifted 0x1B)
+        assert_eq!(char_to_scancode('[', false, us), Some((0x1A, false, false)));
+        // ] is unshifted 0x1B on US (JIS would emit unshifted 0x2B)
+        assert_eq!(char_to_scancode(']', false, us), Some((0x1B, false, false)));
+        // \ is unshifted 0x2B on US (JIS would emit Yen 0x7D)
+        assert_eq!(
+            char_to_scancode('\\', false, us),
+            Some((0x2B, false, false))
+        );
+        // = is unshifted on US (JIS would emit Shift+- so 0x0C+shift)
+        assert_eq!(char_to_scancode('=', false, us), Some((0x0D, false, false)));
+        // ` is unshifted 0x29 on US
+        assert_eq!(char_to_scancode('`', false, us), Some((0x29, false, false)));
+        // IME-on JP punctuation still works on US (driven by IME, not physical layout)
+        assert_eq!(char_to_scancode('。', true, us), Some((0x34, false, false)));
+        // 「 / 」 must use the US scancode for the [ / ] physical keys (Mozc maps these to the JP brackets)
+        assert_eq!(char_to_scancode('「', true, us), Some((0x1A, false, false)));
+        assert_eq!(char_to_scancode('」', true, us), Some((0x1B, false, false)));
+        // JIS path stays unchanged
+        let jis = KeyboardLayout::Jis;
+        assert_eq!(
+            char_to_scancode('「', true, jis),
+            Some((0x1B, false, false))
+        );
+        assert_eq!(
+            char_to_scancode('」', true, jis),
+            Some((0x2B, false, false))
+        );
     }
 
     use crate::parser::parse_layout_content;

--- a/crates/kikyo-core/src/keyboard_map.rs
+++ b/crates/kikyo-core/src/keyboard_map.rs
@@ -1,6 +1,14 @@
 use crate::types::{Rc, ScKey};
 use std::collections::HashMap;
 
+/// Coarse keyboard layout family, used to drive char->scancode conversion on the output side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyboardLayout {
+    Jis,
+    Us,
+    Ax,
+}
+
 /// Provides dynamic keyboard layout mapping (Scancode <-> Row/Col, Scancode <-> KeyName)
 #[derive(Debug, Clone)]
 pub struct KeyboardMap {
@@ -56,6 +64,19 @@ impl KeyboardMap {
 
     pub fn key_name_to_sc(&self, name: &str) -> Option<u16> {
         self.name_to_sc.get(name).copied()
+    }
+
+    /// Returns the coarse keyboard family inferred from the map's name.
+    /// Used by the output path (char->scancode) to pick the right symbol table.
+    pub fn layout(&self) -> KeyboardLayout {
+        let n = self.name.to_ascii_uppercase();
+        if n.starts_with("US") {
+            KeyboardLayout::Us
+        } else if n.starts_with("AX") {
+            KeyboardLayout::Ax
+        } else {
+            KeyboardLayout::Jis
+        }
     }
 
     pub fn load_from_file(


### PR DESCRIPTION
## 概要

出力側の `char_to_scancode` が JIS 配列固定だったため、US 101/104（および
AX）配列環境で記号・シフト記号（`' " @ # $ % ^ & ( ) [ ] \ ` = ` 等）が
誤った scancode で送出され、別の文字として出力されていました。また IME
変換時の `「` `」` は物理ブラケットキーに対応しますが、その scancode が
JIS と US で異なるにもかかわらず JIS 固定で送られていました。`main` には
既に部分的な US 対応がありますが出力側の文字->scancode テーブルが JIS 固定
だったため記号・鉤括弧で破綻していたもので、その出力パスを keyboard
layout に応じて正しい scancode を選ぶよう拡張・修正します。

詳細・根本原因・再現はコミットメッセージに記載しています。

## 変更内容

- `keyboard_map.rs`: layout 系統 `KeyboardLayout`（Jis / Us / Ax）と、
  map 名から系統を推定する `layout()` を追加（未マッチは Jis 既定＝
  既存挙動を保全）
- `engine.rs`: US 101/104 の記号 scancode テーブル `char_to_scancode_us`
  を追加。`char_to_scancode` に `kb_layout` 引数を足し、US/AX のときのみ
  US テーブルを優先（英数字・空白等は JIS と同一のため扱わず JIS テーブル
  へフォールバック）。IME-on の `「` `」` は layout 別に物理ブラケットキー
  の scancode を選択。`append_keystroke_events` へ active layout を渡す
  経路を追加。回帰テスト 2 件（`test_char_to_scancode` を 3 引数化＝JIS
  経路不変を確認、`test_char_to_scancode_us` を新規追加）

## テスト

`upstream/main` 基点の単独 worktree で `cargo test -p kikyo-core --lib` を複数回実行して検証しました。

- 本 PR が追加したテストは、複数回の実行ですべて決定的に通過します。
- `upstream/main` 自体に本 PR と無関係の既存失敗テストがあります。次の 4 件は `upstream/main` 単独で決定的に失敗します: `test_romaji_pinky_shift_fullwidth_uppercase_emits_uppercase_keystroke`, `test_romaji_pinky_shift_kana_sends_romaji_scancodes`, `test_shift_rollover_chord_fallback_preserves_shift`, `test_shifted_layout`（加えて統合テスト `test_ctrl`）。さらに shift / rollover 系の時間依存テスト（`test_pinky_shift_rollover_bypass_keeps_shifted_state` 等）が実行環境の負荷により断続的に失敗し、失敗するテストの顔ぶれと件数が run ごとに揺れます（この負荷依存の集合は網羅的には列挙できません）。
- これらはいずれも本 PR と無関係です。`upstream/main` と本 PR を同条件で複数回実行して比較した結果、失敗するテスト名の集合は一致し、本 PR が新たに失敗させるテストはありません（本 PR 起因の新規失敗ゼロ）。

## 関連 PR

これは `forestail/Kikyo` の複数の独立した不具合を、論理バグ単位で個別の PR に分割した一連の修正の一つです。各 PR は `upstream/main` から独立に分岐し、単独でビルド・テストが通ります。

- parser の修飾子プレフィックス誤認修正（`parser.rs`）
- 未定義 3 キー chord の 2 キー分解（`engine.rs`）
- ロール入力時の chord 検出・pending 修正（`chord_engine.rs` ＋ `engine.rs` の `PendingKey` 初期化）
- US 101/104 配列の scancode 修正（`engine.rs` ＋ `keyboard_map.rs`）
- 空 DirectString の no-op 化 ＋ shift 再注入修正（`engine.rs` の `append_keystroke_events`）

これらはファイル・変更領域が分離しており、任意の順序でマージできます。

- US 101/104 scancode 修正 は `append_keystroke_events` のレイアウト対応版（`append_keystroke_events_layout`）を追加し、従来の `append_keystroke_events`（シグネチャ不変）はそれへ委譲する後方互換ラッパーとして残します。他 PR を含む既存の呼び出し側は変更不要です。
- chord 検出修正 は `PendingKey` にフィールドを追加し、その初期化箇所も同 PR 内で更新します（自己完結）。他 PR は `PendingKey` を新規構築しないため影響を受けません。

Closes #12
