### PR TITLE
fix(engine): inject 出力パスの 2 件の修正（空 DirectString の no-op 化／shift_held 時の shift 再注入）

### DIFF
--- a/crates/kikyo-core/src/engine.rs
+++ b/crates/kikyo-core/src/engine.rs
@@ -2382,9 +2382,16 @@ fn append_keystroke_events(
             mods.shift = true;
         }
 
-        if mods.shift && shift_held {
-            mods.shift = false;
-        }
+        // Note: we deliberately do NOT skip shift injection when shift_held is true.
+        // The injected events run on a worker thread some milliseconds after the
+        // hook observed the physical shift. If the user releases the physical shift
+        // very quickly (faster than the worker delay), the OS shift state will be
+        // up by the time we SendInput the scancode, and a shifted symbol like '('
+        // would degrade to '9'. Re-injecting the shift modifier here is safe even
+        // when the user is still physically holding shift, because subsequent hook
+        // callbacks rely on GetAsyncKeyState (which tracks physical state, not
+        // injected state) to recover the held condition.
+        let _ = shift_held;
 
         let mods_evs = modifier_scancodes(mods);
         for (mod_sc, mod_ext) in mods_evs.iter() {
@@ -6471,5 +6478,47 @@ xx
             }
             other => panic!("Expected Inject, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_shift_modifier_reinjected_when_shift_held() {
+        // F5: `append_keystroke_events` must NOT drop the shift modifier when
+        // `shift_held` is true. The inject runs on a worker thread some
+        // milliseconds after the hook observed the physical shift; if the user
+        // releases shift faster than that delay, dropping the modifier here
+        // would degrade a shifted stroke (mods.shift = true, e.g. Shift+a) to
+        // a bare 'a'. The modifier must be re-injected regardless of
+        // shift_held.
+        let stroke = KeyStroke {
+            key: KeySpec::Char('a'),
+            mods: Modifiers {
+                shift: true,
+                ctrl: false,
+                alt: false,
+                win: false,
+            },
+        };
+        let mut events = Vec::new();
+        // shift_held = true is the exact case the old code mishandled: it
+        // skipped the shift modifier here.
+        append_keystroke_events(&mut events, &stroke, true, false, false, false);
+
+        // The shift modifier scancode (0x2A) must be present despite
+        // shift_held being true.
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, InputEvent::Scancode(0x2A, _, _))),
+            "shift modifier (0x2A) must be re-injected when shift_held, got {:?}",
+            events
+        );
+        // The 'a' scancode (0x1E) is still emitted.
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, InputEvent::Scancode(0x1E, _, _))),
+            "expected 'a' scancode 0x1E in {:?}",
+            events
+        );
     }
 }

--- a/crates/kikyo-core/src/engine.rs
+++ b/crates/kikyo-core/src/engine.rs
@@ -2361,9 +2361,17 @@ fn append_keystroke_events(
             return;
         }
         KeySpec::DirectString(ref s) => {
-            // Hand off the complex IME handling logic to the hook (outside the lock).
-            // This avoids deadlock when calling IME APIs while holding the Engine lock.
-            events.push(InputEvent::DirectString(s.clone()));
+            // Empty DirectString cells (e.g. `""` in a layout) are conventionally
+            // used as a "block" marker for a physical key. Emitting an empty
+            // DirectString triggers IME-control side effects (composition commit,
+            // IME state notifications) on the hook side, which surprised users
+            // who only intended a no-op. Skip the event when the string is empty
+            // so the cell still blocks pass-through but stays a true no-op.
+            if !s.is_empty() {
+                // Hand off the complex IME handling logic to the hook (outside the lock).
+                // This avoids deadlock when calling IME APIs while holding the Engine lock.
+                events.push(InputEvent::DirectString(s.clone()));
+            }
             return;
         }
     };
@@ -6414,6 +6422,54 @@ xx
                 }
             }
             other => panic!("Expected Inject for direct string + key, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_empty_directstring_is_noop() {
+        // An empty DirectString cell (`""`) is used as a "block" marker: it must
+        // suppress pass-through WITHOUT emitting an empty DirectString event,
+        // which would otherwise trigger IME-control side effects (composition
+        // commit, IME state notifications) on the hook side. A non-empty
+        // DirectString is unchanged. Layout: row2 col0 = `""` then `b`.
+        let config = "
+[ローマ字シフト無し]
+xx
+xx
+\"\"b
+";
+        let layout =
+            crate::parser::parse_layout_content(config, &crate::keyboard_map::new_jis_106())
+                .expect("Failed to parse config");
+
+        let mut engine = Engine::default();
+        engine.set_ignore_ime(true);
+        engine.load_layout(layout);
+
+        // 'a' (0x1E) -> "" (empty DirectString, must be skipped) then 'b' (0x30)
+        assert_eq!(
+            engine.process_key(0x1E, false, false, false),
+            KeyAction::Block
+        );
+        let res = engine.process_key(0x1E, false, true, false);
+        match res {
+            KeyAction::Inject(evs) => {
+                // No DirectString event must be emitted for the empty cell.
+                assert!(
+                    !evs.iter().any(|e| matches!(e, InputEvent::DirectString(_))),
+                    "empty DirectString must be skipped, got {:?}",
+                    evs
+                );
+                // The following `b` key is still emitted (non-DirectString path
+                // unchanged): down of scancode 0x30.
+                assert!(
+                    evs.iter()
+                        .any(|e| matches!(e, InputEvent::Scancode(0x30, _, false))),
+                    "expected `b` (0x30) down in {:?}",
+                    evs
+                );
+            }
+            other => panic!("Expected Inject, got {:?}", other),
         }
     }
 }


### PR DESCRIPTION
## 概要

engine の出力注入パスにおける独立した 2 件の不具合を、1 PR / 2 コミットで
修正します（根本原因が別物のため commit を分離。レビュアーが個別に追跡可能）。

1. **空 DirectString の no-op 化**（commit 1, D）:
   値が空文字列 `""` のセルは「ブロック（何も出力しない）」マーカーと
   して使われるが、空の `DirectString` が送出され hook 側で IME 制御の
   副作用（変換確定・IME 状態通知）を起こしていた。空文字列のとき
   イベントを送出せず、セルは従来どおりブロックしつつ真の no-op にする。
2. **shift_held 時の shift 再注入**（commit 2, F5）:
   hook↔inject(SendInput) のレイテンシにより、SendInput 発火前に
   ユーザーが物理 shift を離すと shift 修飾が脱落し「Shift+9」が「9」に
   劣化していた。`shift_held` でも shift 修飾子の再注入をスキップしない
   よう変更（hook は GetAsyncKeyState で物理状態を追跡＝再注入は安全）。

詳細・再現は各コミットメッセージに記載しています。

## 変更内容

- `crates/kikyo-core/src/engine.rs` の `append_keystroke_events` 周辺。
  commit1（D）= `DirectString` アームで空文字列のときイベント送出を抑止
  ＋ D 回帰テスト。commit2（F5）= `shift_held` でも shift 修飾子の
  scancode を再注入 ＋ F5 回帰テスト。隣接ブロックのため 1 ブランチに
  同梱し、根本原因が別物のため commit を分離。

## テスト

`upstream/main` 基点の単独 worktree で `cargo test -p kikyo-core --lib` を複数回実行して検証しました。

- 本 PR が追加したテストは、複数回の実行ですべて決定的に通過します。
- `upstream/main` 自体に本 PR と無関係の既存失敗テストがあります。次の 4 件は `upstream/main` 単独で決定的に失敗します: `test_romaji_pinky_shift_fullwidth_uppercase_emits_uppercase_keystroke`, `test_romaji_pinky_shift_kana_sends_romaji_scancodes`, `test_shift_rollover_chord_fallback_preserves_shift`, `test_shifted_layout`（加えて統合テスト `test_ctrl`）。さらに shift / rollover 系の時間依存テスト（`test_pinky_shift_rollover_bypass_keeps_shifted_state` 等）が実行環境の負荷により断続的に失敗し、失敗するテストの顔ぶれと件数が run ごとに揺れます（この負荷依存の集合は網羅的には列挙できません）。
- これらはいずれも本 PR と無関係です。`upstream/main` と本 PR を同条件で複数回実行して比較した結果、失敗するテスト名の集合は一致し、本 PR が新たに失敗させるテストはありません（本 PR 起因の新規失敗ゼロ）。

## 関連 PR

これは `forestail/Kikyo` の複数の独立した不具合を、論理バグ単位で個別の PR に分割した一連の修正の一つです。各 PR は `upstream/main` から独立に分岐し、単独でビルド・テストが通ります。

- parser の修飾子プレフィックス誤認修正（`parser.rs`）
- 未定義 3 キー chord の 2 キー分解（`engine.rs`）
- ロール入力時の chord 検出・pending 修正（`chord_engine.rs` ＋ `engine.rs` の `PendingKey` 初期化）
- US 101/104 配列の scancode 修正（`engine.rs` ＋ `keyboard_map.rs`）
- 空 DirectString の no-op 化 ＋ shift 再注入修正（`engine.rs` の `append_keystroke_events`）

これらはファイル・変更領域が分離しており、任意の順序でマージできます。

- US 101/104 scancode 修正 は `append_keystroke_events` のレイアウト対応版（`append_keystroke_events_layout`）を追加し、従来の `append_keystroke_events`（シグネチャ不変）はそれへ委譲する後方互換ラッパーとして残します。他 PR を含む既存の呼び出し側は変更不要です。
- chord 検出修正 は `PendingKey` にフィールドを追加し、その初期化箇所も同 PR 内で更新します（自己完結）。他 PR は `PendingKey` を新規構築しないため影響を受けません。

Closes #13
Closes #14
