### PR TITLE
Codex/fix pr19 shift injection

### DIFF
--- a/crates/kikyo-core/src/analytics.rs
+++ b/crates/kikyo-core/src/analytics.rs
@@ -278,6 +278,12 @@ pub fn count_output_virtual_keys(
                     }
                 }
             }
+            crate::types::InputEvent::ModifiedScancode(sc, _ext, _mods) => {
+                let sc_key = crate::types::ScKey::new(*sc, false);
+                if keyboard_map.sc_to_rc.contains_key(&sc_key) {
+                    count += 1;
+                }
+            }
             crate::types::InputEvent::Unicode(_, up) => {
                 if !up {
                     count += 1;
@@ -338,16 +344,17 @@ mod tests {
 
     #[test]
     fn test_count_output_virtual_keys() {
-        use crate::types::InputEvent;
+        use crate::types::{InputEvent, Modifiers};
         let map = crate::keyboard_map::new_jis_106();
         let events = vec![
             InputEvent::Scancode(0x1E, false, false), // 'a' down (character key)
             InputEvent::Scancode(0x1E, false, true),  // 'a' up
+            InputEvent::ModifiedScancode(0x30, false, Modifiers::none()), // 'b'
             InputEvent::Unicode('あ', false),          // unicode down
             InputEvent::Unicode('あ', true),           // unicode up
             InputEvent::DirectString("こんにちは".to_string()),
         ];
-        assert_eq!(count_output_virtual_keys(&events, &map), 7); // 1 + 1 + 5
+        assert_eq!(count_output_virtual_keys(&events, &map), 8); // 1 + 1 + 1 + 5
     }
 
     #[test]

--- a/crates/kikyo-core/src/engine.rs
+++ b/crates/kikyo-core/src/engine.rs
@@ -2555,7 +2555,8 @@ fn append_keystroke_events_layout(
         }
 
         if mods.shift && shift_held {
-            mods.shift = false;
+            events.push(InputEvent::ModifiedScancode(sc, ext, mods));
+            return;
         }
 
         let mods_evs = modifier_scancodes(mods);
@@ -6986,6 +6987,32 @@ xx
                 );
             }
             other => panic!("Expected Inject, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_shift_held_shifted_output_uses_modified_scancode() {
+        let stroke = KeyStroke {
+            key: KeySpec::Char('a'),
+            mods: Modifiers {
+                shift: true,
+                ctrl: false,
+                alt: false,
+                win: false,
+            },
+        };
+        let mut events = Vec::new();
+
+        append_keystroke_events(&mut events, &stroke, true, false, false, false);
+
+        assert_eq!(events.len(), 1);
+        match events[0] {
+            InputEvent::ModifiedScancode(sc, ext, mods) => {
+                assert_eq!(sc, 0x1E);
+                assert!(!ext);
+                assert!(mods.shift);
+            }
+            ref other => panic!("expected ModifiedScancode, got {:?}", other),
         }
     }
 }

--- a/crates/kikyo-core/src/engine.rs
+++ b/crates/kikyo-core/src/engine.rs
@@ -2533,9 +2533,17 @@ fn append_keystroke_events_layout(
             return;
         }
         KeySpec::DirectString(ref s) => {
-            // Hand off the complex IME handling logic to the hook (outside the lock).
-            // This avoids deadlock when calling IME APIs while holding the Engine lock.
-            events.push(InputEvent::DirectString(s.clone()));
+            // Empty DirectString cells (e.g. `""` in a layout) are conventionally
+            // used as a "block" marker for a physical key. Emitting an empty
+            // DirectString triggers IME-control side effects (composition commit,
+            // IME state notifications) on the hook side, which surprised users
+            // who only intended a no-op. Skip the event when the string is empty
+            // so the cell still blocks pass-through but stays a true no-op.
+            if !s.is_empty() {
+                // Hand off the complex IME handling logic to the hook (outside the lock).
+                // This avoids deadlock when calling IME APIs while holding the Engine lock.
+                events.push(InputEvent::DirectString(s.clone()));
+            }
             return;
         }
     };
@@ -6930,6 +6938,54 @@ xx
                 }
             }
             other => panic!("Expected Inject for direct string + key, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_empty_directstring_is_noop() {
+        // An empty DirectString cell (`""`) is used as a "block" marker: it must
+        // suppress pass-through WITHOUT emitting an empty DirectString event,
+        // which would otherwise trigger IME-control side effects (composition
+        // commit, IME state notifications) on the hook side. A non-empty
+        // DirectString is unchanged. Layout: row2 col0 = `""` then `b`.
+        let config = "
+[ローマ字シフト無し]
+xx
+xx
+\"\"b
+";
+        let layout =
+            crate::parser::parse_layout_content(config, &crate::keyboard_map::new_jis_106())
+                .expect("Failed to parse config");
+
+        let mut engine = Engine::default();
+        engine.set_ignore_ime(true);
+        engine.load_layout(layout);
+
+        // 'a' (0x1E) -> "" (empty DirectString, must be skipped) then 'b' (0x30)
+        assert_eq!(
+            engine.process_key(0x1E, false, false, false),
+            KeyAction::Block
+        );
+        let res = engine.process_key(0x1E, false, true, false);
+        match res {
+            KeyAction::Inject(evs) => {
+                // No DirectString event must be emitted for the empty cell.
+                assert!(
+                    !evs.iter().any(|e| matches!(e, InputEvent::DirectString(_))),
+                    "empty DirectString must be skipped, got {:?}",
+                    evs
+                );
+                // The following `b` key is still emitted (non-DirectString path
+                // unchanged): down of scancode 0x30.
+                assert!(
+                    evs.iter()
+                        .any(|e| matches!(e, InputEvent::Scancode(0x30, _, false))),
+                    "expected `b` (0x30) down in {:?}",
+                    evs
+                );
+            }
+            other => panic!("Expected Inject, got {:?}", other),
         }
     }
 }

--- a/crates/kikyo-core/src/keyboard_hook/macos.rs
+++ b/crates/kikyo-core/src/keyboard_hook/macos.rs
@@ -388,6 +388,23 @@ fn win_to_mac(sc: u16, ext: bool) -> u16 {
     }
 }
 
+fn event_flags_for_modifiers(mods: crate::types::Modifiers) -> u64 {
+    let mut flags = 0;
+    if mods.shift {
+        flags |= kCGEventFlagMaskShift;
+    }
+    if mods.ctrl {
+        flags |= kCGEventFlagMaskControl;
+    }
+    if mods.alt {
+        flags |= kCGEventFlagMaskAlternate;
+    }
+    if mods.win {
+        flags |= kCGEventFlagMaskCommand;
+    }
+    flags
+}
+
 extern "C" fn tap_callback(
     _proxy: CGEventTapProxy,
     type_: CGEventType,
@@ -684,6 +701,11 @@ pub fn install_hook() -> anyhow::Result<()> {
                                     }
                                 }
                                 let _ = inject_scancode_with_flags(sc, ext, up, injected_flags);
+                            }
+                            InputEvent::ModifiedScancode(sc, ext, mods) => {
+                                let flags = injected_flags | event_flags_for_modifiers(mods);
+                                let _ = inject_scancode_with_flags(sc, ext, false, flags);
+                                let _ = inject_scancode_with_flags(sc, ext, true, flags);
                             }
                             InputEvent::Unicode(c, up) => {
                                 let _ = inject_unicode_with_flags(c, up, injected_flags);

--- a/crates/kikyo-core/src/keyboard_hook/windows.rs
+++ b/crates/kikyo-core/src/keyboard_hook/windows.rs
@@ -263,6 +263,69 @@ fn captured_shift_down_snapshot() -> (bool, bool) {
     (state.left.physical_down, state.right.physical_down)
 }
 
+fn modifier_scancodes_for_injection(mods: crate::types::Modifiers) -> Vec<(u16, bool)> {
+    let mut scancodes = Vec::new();
+    if mods.ctrl {
+        scancodes.push((0x1D, false));
+    }
+    if mods.shift {
+        scancodes.push((0x2A, false));
+    }
+    if mods.alt {
+        scancodes.push((0x38, false));
+    }
+    if mods.win {
+        scancodes.push((0x5B, true));
+    }
+    scancodes
+}
+
+fn virtual_key_is_down(vk: i32) -> bool {
+    unsafe { GetAsyncKeyState(vk) as u16 & 0x8000 != 0 }
+}
+
+fn shift_available_for_modified_injection() -> bool {
+    let state = lock_captured_shift_state();
+
+    let left_available = virtual_key_is_down(VK_LSHIFT.0 as i32)
+        && !(state.left.physical_down && !state.left.os_down_sent);
+    let right_available = virtual_key_is_down(VK_RSHIFT.0 as i32)
+        && !(state.right.physical_down && !state.right.os_down_sent);
+
+    left_available || right_available
+}
+
+fn modifier_available_for_injection(sc: u16, ext: bool) -> bool {
+    match (sc, ext) {
+        (0x2A, false) | (0x36, false) => shift_available_for_modified_injection(),
+        _ => false,
+    }
+}
+
+fn inject_modified_scancode(
+    sc: u16,
+    ext: bool,
+    mods: crate::types::Modifiers,
+) -> anyhow::Result<()> {
+    let mut injected_mods = Vec::new();
+
+    for (mod_sc, mod_ext) in modifier_scancodes_for_injection(mods) {
+        if !modifier_available_for_injection(mod_sc, mod_ext) {
+            inject_scancode(mod_sc, mod_ext, false)?;
+            injected_mods.push((mod_sc, mod_ext));
+        }
+    }
+
+    inject_scancode(sc, ext, false)?;
+    inject_scancode(sc, ext, true)?;
+
+    for (mod_sc, mod_ext) in injected_mods.into_iter().rev() {
+        inject_scancode(mod_sc, mod_ext, true)?;
+    }
+
+    Ok(())
+}
+
 fn clear_captured_shift_state() {
     let mut state = lock_captured_shift_state();
     *state = CapturedShiftState::default();
@@ -819,6 +882,9 @@ fn process_event(event: HookEvent) {
                 match ev {
                     InputEvent::Scancode(sc, ext, up) => {
                         let _ = inject_scancode(sc, ext, up);
+                    }
+                    InputEvent::ModifiedScancode(sc, ext, mods) => {
+                        let _ = inject_modified_scancode(sc, ext, mods);
                     }
                     InputEvent::Unicode(c, up) => {
                         let _ = inject_unicode(c, up);

--- a/crates/kikyo-core/src/types.rs
+++ b/crates/kikyo-core/src/types.rs
@@ -29,6 +29,8 @@ pub struct ShortcutKey {
 pub enum InputEvent {
     /// Scancode injection (scancode, ext, up).
     Scancode(u16, bool, bool),
+    /// Press and release a scancode with modifiers resolved at injection time.
+    ModifiedScancode(u16, bool, Modifiers),
     /// Unicode character injection (char, up).
     Unicode(char, bool),
     /// Commit current IME composition if any.


### PR DESCRIPTION
#19 のうち空 DirectString no-op 化を取り込み
shift_held 時の Shift 再注入は、固定の Shift down/up ではなく送出直前解決に変更
ModifiedScancode を追加し、Windows hook 側で必要な場合だけ一時Shift注入
Closes #19